### PR TITLE
Bump automesh version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 requires-python = ">=3.11, <3.12"
 dependencies = [
-    "automesh==0.2.9",
+    "automesh==0.3.1",
     "connected-components-3d==3.18.0",
     "fastremap==1.14.1",
     "h5py==3.11.0",


### PR DESCRIPTION
We added more wheels in the recent `automesh` release that should let more users `pip install automesh` using binary distributions instead of the source distribution.